### PR TITLE
#5 Include discount from promotional adjustments

### DIFF
--- a/lib/spree_usa_epay/client.rb
+++ b/lib/spree_usa_epay/client.rb
@@ -162,6 +162,7 @@ module SpreeUsaEpay
         'Tax' => double_money(gateway_options[:tax]),
         'Subtotal' => double_money(gateway_options[:subtotal]),
         'Shipping' => double_money(gateway_options[:shipping]),
+        'Discount' => double_money(gateway_options[:discount]),
         'OrderID' => gateway_options[:order_id] }
     end
 


### PR DESCRIPTION
USA ePay gateway requires that:

total = subtotal + shipping + tax - discount

Therefore, need to send discount amount as well.
