### PR TITLE
Fix issue trying get the year in 2 digits

### DIFF
--- a/lib/spree_usa_epay/client.rb
+++ b/lib/spree_usa_epay/client.rb
@@ -236,7 +236,7 @@ module SpreeUsaEpay
     end
 
     def expiration_date(creditcard)
-      ("%.2i" %  creditcard.month) + creditcard.year[2,2]
+      ("%.2i" %  creditcard.month) + creditcard.year.to_s[2,2]
     end
 
   end


### PR DESCRIPTION
On spree 2.2 the creditcard.year is "Fixnum" and it's trying to get the last 2 digits ([2,2]) but this is only for strings
